### PR TITLE
Rework synthetizer sample rate configuration

### DIFF
--- a/src/audio/midi_sequencer.rs
+++ b/src/audio/midi_sequencer.rs
@@ -25,6 +25,10 @@ impl MidiSequencer {
         }
     }
 
+    pub fn events(&self) -> &[MidiEvent] {
+        &self.sorted_events
+    }
+
     pub fn set_tick(&mut self, tick: usize) {
         self.last_tick = tick;
         self.current_tick = tick;


### PR DESCRIPTION
This PR reworks the synthesizer configuration to accept more diverse setups.

It no longer panics if it does not find:
- 44100hz as sampling rater
- 2 output channels

Given that the synthesizer depends on the sampling rate of the default output picked by `cpal`, I decided to create a default synthesizer and only update it if necessary.  