### PR TITLE
handle cpal errors before starting playback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ pub fn main_result() -> Result<(), RuxError> {
 
     // args
     let mut args = CliArgs::parse();
+    let file = args.file.take().map(PathBuf::from);
     let sound_font_file = args.sound_font_file.take().map(PathBuf::from);
 
     // check if sound font file exists
@@ -39,6 +40,7 @@ pub fn main_result() -> Result<(), RuxError> {
     }
 
     let args = ApplicationArgs {
+        file,
         sound_font_bank: sound_font_file,
         no_antialiasing: args.no_antialiasing,
     };
@@ -51,6 +53,10 @@ pub fn main_result() -> Result<(), RuxError> {
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
+    /// Optional path to a gp5 file. If not passed, a file must be selected with
+    /// the file selector.
+    #[arg(long)]
+    file: Option<String>,
     /// Optional path to a sound font file.
     #[arg(long)]
     sound_font_file: Option<String>,
@@ -61,6 +67,7 @@ pub struct CliArgs {
 
 #[derive(Debug, Clone)]
 pub struct ApplicationArgs {
+    file: Option<PathBuf>,
     sound_font_bank: Option<PathBuf>,
     no_antialiasing: bool,
 }

--- a/src/ui/application.rs
+++ b/src/ui/application.rs
@@ -126,10 +126,7 @@ pub enum Message {
 }
 
 impl RuxApplication {
-    fn new(
-        file: Option<PathBuf>,
-        sound_font_file: Option<PathBuf>,
-    ) -> Self {
+    fn new(file: Option<PathBuf>, sound_font_file: Option<PathBuf>) -> Self {
         let (beat_sender, beat_receiver) = tokio::sync::watch::channel(0);
         let mut app = Self {
             song_info: None,

--- a/src/ui/application.rs
+++ b/src/ui/application.rs
@@ -126,9 +126,12 @@ pub enum Message {
 }
 
 impl RuxApplication {
-    fn new(sound_font_file: Option<PathBuf>) -> Self {
+    fn new(
+        file: Option<PathBuf>,
+        sound_font_file: Option<PathBuf>,
+    ) -> Self {
         let (beat_sender, beat_receiver) = tokio::sync::watch::channel(0);
-        Self {
+        let mut app = Self {
             song_info: None,
             track_selection: TrackSelection::default(),
             all_tracks: vec![],
@@ -140,7 +143,13 @@ impl RuxApplication {
             sound_font_file,
             beat_receiver: Arc::new(Mutex::new(beat_receiver)),
             beat_sender: Arc::new(beat_sender),
+        };
+        if let Some(file) = file {
+            let path = file.clone().into_os_string().into_string().unwrap();
+            let content = fs::read(path.clone()).unwrap();
+            app.update(Message::FileOpened(Ok((content, path))));
         }
+        app
     }
 
     pub fn start(args: ApplicationArgs) -> iced::Result {

--- a/src/ui/application.rs
+++ b/src/ui/application.rs
@@ -143,7 +143,7 @@ impl RuxApplication {
         };
         if let Some(file) = file {
             let path = file.clone().into_os_string().into_string().unwrap();
-            let content = fs::read(path.clone()).unwrap();
+            let content = std::fs::read(path.clone()).unwrap();
             app.update(Message::FileOpened(Ok((content, path))));
         }
         app
@@ -164,7 +164,7 @@ impl RuxApplication {
         .antialiasing(!args.no_antialiasing)
         .run_with(move || {
             (
-                RuxApplication::new(args.sound_font_bank.clone()),
+                RuxApplication::new(args.file.clone(), args.sound_font_bank.clone()),
                 Task::none(),
             )
         })


### PR DESCRIPTION
`cpal`'s [`Device::default_output_config()`](https://docs.rs/cpal/latest/cpal/platform/struct.Device.html#method.default_output_config) may panic in edge cases, e.g. when using USB speakers. if this happens, playback should not be started.

A possibly relevant upstream issue (from 2022): https://github.com/RustAudio/cpal/issues/680

Fixes https://github.com/agourlay/ruxguitar/issues/14